### PR TITLE
Update CRD to allow operator-sdk to populate the status fields

### DIFF
--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -12,23 +12,29 @@ spec:
     singular: ansiblejob
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          description: Schema validation for the Tower Job Launch CRD
-          properties:
-            spec:
-              type: object
-              properties:
-                tower_auth_secret:
-                  type: string
-                job_template_name:
-                  type: string
-          required:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+        description: Schema validation for the Tower Job Launch CRD
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              tower_auth_secret:
+                type: string
+              job_template_name:
+                type: string
+            required:
             - tower_auth_secret
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Fix the formatting so the operator-sdk inserted status gets populated properly.

```
status:
  conditions:
  - ansibleResult:
      changed: 1
      completion: 2020-08-05T14:08:13.467034
      failures: 0
      ok: 5
      skipped: 0
    lastTransitionTime: "2020-08-05T14:08:08Z"
    message: Awaiting next reconciliation
    reason: Successful
    status: "True"
    type: Running
```

Signed-off-by: Mike Ng <ming@redhat.com>