### PR TITLE
new target_clusters field for job launch crd

### DIFF
--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -31,6 +31,10 @@ spec:
                 type: string
               job_template_name:
                 type: string
+              target_clusters:
+                type: array
+                items:
+                  type: object
             required:
             - tower_auth_secret
             type: object


### PR DESCRIPTION
As according to discussion between ACM and Ansible teams, this new `target_clusters` field is primary for passing the target cluster list to Ansible tower for future usage. The item type of object instead of string to be more future proof.

Signed-off-by: Mike Ng <ming@redhat.com>