### PR TITLE
after job wait, update the ansiblejob cr with the job result

### DIFF
--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -34,6 +34,17 @@ spec:
             required:
             - tower_auth_secret
             type: object
+          statusAnsibleJob:
+            properties:
+              elapsed:
+                type: string
+              finished:
+                type: string
+              started:
+                type: string
+              status:
+                type: string
+            type: object
     served: true
     storage: true
     subresources:

--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -7,6 +7,7 @@ spec:
   ttlSecondsAfterFinished: 3600
   template:
     spec:
+      serviceAccountName: tower-resource-operator
       containers:
       - name: joblaunch
         image: matburt/operator-job-run:latest

--- a/roles/job_runner/tasks/main.yml
+++ b/roles/job_runner/tasks/main.yml
@@ -16,7 +16,25 @@
         namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
         labels:
           tower_job_id: "{{ job.id }}"
+      statusAnsibleJob:
+        status: "{{ job.status }}"
 
 - name: Wait for job
   tower_job_wait:
     job_id: "{{ job.id }}"
+  register: job_result
+
+- name: Update AnsibleJob definition with Tower job result
+  k8s:
+    state: present
+    definition:
+      kind: AnsibleJob
+      apiVersion: tower.ansible.com/v1alpha1
+      metadata:
+        name: "{{ lookup('env', 'ANSIBLEJOB_NAME') }}"
+        namespace: "{{ lookup('env', 'ANSIBLEJOB_NAMESPACE') }}"
+      statusAnsibleJob:
+        elapsed: "{{ job_result.elapsed }}"
+        finished: "{{ job_result.finished }}"
+        started: "{{ job_result.started }}"
+        status: "{{ job_result.status }}"


### PR DESCRIPTION
```
status:
  conditions:
  - ansibleResult:
      changed: 0
      completion: 2020-08-11T19:51:56.946445
      failures: 0
      ok: 5
      skipped: 0
    lastTransitionTime: "2020-08-11T19:50:52Z"
    message: Awaiting next reconciliation
    reason: Successful
    status: "True"
    type: Running
statusAnsibleJob:
  elapsed: "6.079"
  finished: "2020-08-11T19:51:50.982986Z"
  started: "2020-08-11T19:51:44.903723Z"
  status: successful
```

The` status` its something that operator-sdk stamps it represents the status of "ansible launch kubejob" as long as the kubejob launch successfully. It doesn't matter if the kubejob (or actual ansiblejob) failed or not it will still say "reason: successful". Which is not very useful.
The `statusAnsibleJob` is something I added to the CRD because it doesn't seem like the ansible module allows for modifying the existing status. I think it's similar to when the case where you `kubectl apply` a status change, nothing happens. `statusAnsibleJob` represent its the actual ansible job status that we are interested in.


Signed-off-by: Mike Ng <ming@redhat.com>