### PR TITLE
add extra_vars and invetory to job launch crd

### DIFF
--- a/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/tower.ansible.com_joblaunch_crd.yaml
@@ -31,6 +31,14 @@ spec:
                 type: string
               job_template_name:
                 type: string
+              inventory:
+                type: array
+                items:
+                  type: object
+              extra_vars:
+                type: array
+                items:
+                  type: object
             required:
             - tower_auth_secret
             type: object

--- a/deploy/tower-resource-operator.yaml
+++ b/deploy/tower-resource-operator.yaml
@@ -227,6 +227,14 @@ spec:
                 type: string
               job_template_name:
                 type: string
+              inventory:
+                type: array
+                items:
+                  type: object
+              extra_vars:
+                type: array
+                items:
+                  type: object
             required:
             - tower_auth_secret
             type: object


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

These are fields that future proof the job launch CRD. There are a few optional params for job launch specify here: https://docs.ansible.com/ansible/latest/modules/tower_job_launch_module.html#parameters

for example Xiangjing suggested to leverage the `extra_vars` to pass in target clusters for ACM in the future.
> extra_vars, inventory  we are currently running ansible-runner -r job_runner run /runner  cli in the job container.  The default values of the two parameters are in /runner directory. If you go inside of the operator pod, the extra_vars, inventory are located under the runner directory /tmp/ansible-operator/runner/tower.ansible.com/v1alpha1/AnsibleJob/tower/bigjoblaunch  I am thinking we may add those 2 fields into the AnsibleJob CRD spec. we may add our target cluster lists to the spec.extra_vars
