### PR TITLE
kube job name should be unique 

### DIFF
--- a/roles/job/templates/job_definition.yml
+++ b/roles/job/templates/job_definition.yml
@@ -1,12 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ meta.name }}"
+  name: "{{ meta.name + '-' + (99999999 | random | to_uuid)[:8] }}"
   namespace: "{{ meta.namespace }}"
 spec:
   ttlSecondsAfterFinished: 3600
   template:
     spec:
+      serviceAccountName: tower-resource-operator
       containers:
       - name: joblaunch
         image: matburt/operator-job-run:latest


### PR DESCRIPTION
kube job name should be unique enough so that a update to ansiblejob CR can create a new kube job and not patch the old one which runs into an error.

Signed-off-by: Mike Ng <ming@redhat.com>